### PR TITLE
Update mysql-db service command inside  mysql.yml file

### DIFF
--- a/mysql.yml
+++ b/mysql.yml
@@ -6,7 +6,7 @@ services:
     image: mysql:latest
     container_name: mysql-db
     hostname: mysql-db
-    command: --default-authentication-plugin=mysql_native_password
+    command: ["mysqld", "--mysql-native-password=ON"]
     restart: always
     volumes:
       - ./databases:/usr/databases


### PR DESCRIPTION
I found an issue with the command inside the mysql-db service.  the provided  command didn't allow the mysql-db service bootup so I replaced it with the 
 ( ["mysqld", "--mysql-native-password=ON"]  ) and the issue is gone.