### PR TITLE
mysql-db container error resolved

### DIFF
--- a/mysql.yml
+++ b/mysql.yml
@@ -6,7 +6,6 @@ services:
     image: mysql:latest
     container_name: mysql-db
     hostname: mysql-db
-    command: --default-authentication-plugin=mysql_native_password
     restart: always
     volumes:
       - ./databases:/usr/databases


### PR DESCRIPTION
Remove the `command: --default-authentication-plugin=mysql_native_password` line from docker-compose.yml
and it will work on mysql:latest clearly.
MySQL 8.0+ uses a different authentication mechanism, and the native password plugin may not be required.